### PR TITLE
Fix Broken Battle Initialization

### DIFF
--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -66,34 +66,34 @@ void HandleLinkBattleSetup(void)
     }
 }
 
-// void SetUpBattleVarsAndBirchZigzagoon(void)
-// {
-//     s32 i;
-//
-//     gBattleMainFunc = BeginBattleIntroDummy;
-//
-//     for (i = 0; i < MAX_BATTLERS_COUNT; i++)
-//     {
-//         gBattlerControllerFuncs[i] = BattleControllerDummy;
-//         gBattlerPositions[i] = 0xFF;
-//         gActionSelectionCursor[i] = 0;
-//         gMoveSelectionCursor[i] = 0;
-//     }
-//
-//     HandleLinkBattleSetup();
-//     gBattleControllerExecFlags = 0;
-//     ClearBattleAnimationVars();
-//     BattleAI_SetupItems();
-//     BattleAI_SetupFlags();
-//
-//     if (gBattleTypeFlags & BATTLE_TYPE_FIRST_BATTLE)
-//     {
+void SetUpBattleVarsAndBirchZigzagoon(void)
+{
+    s32 i;
+
+    gBattleMainFunc = BeginBattleIntroDummy;
+
+    for (i = 0; i < MAX_BATTLERS_COUNT; i++)
+    {
+        gBattlerControllerFuncs[i] = BattleControllerDummy;
+        gBattlerPositions[i] = 0xFF;
+        gActionSelectionCursor[i] = 0;
+        gMoveSelectionCursor[i] = 0;
+    }
+
+    HandleLinkBattleSetup();
+    gBattleControllerExecFlags = 0;
+    ClearBattleAnimationVars();
+    BattleAI_SetupItems();
+    BattleAI_SetupFlags();
+
+    // if (gBattleTypeFlags & BATTLE_TYPE_FIRST_BATTLE)
+    // {
     //     ZeroEnemyPartyMons();
     //     CreateMon(&gEnemyParty[0], SPECIES_ZIGZAGOON, 2, USE_RANDOM_IVS, 0, 0, OT_ID_PLAYER_ID, 0);
     //     i = 0;
     //     SetMonData(&gEnemyParty[0], MON_DATA_HELD_ITEM, &i);
-//     }
-// }
+    // }
+}
 
 void InitBattleControllers(void)
 {

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -548,7 +548,7 @@ static void CB2_InitBattleInternal(void)
     FreeAllSpritePalettes();
     gReservedSpritePaletteCount = MAX_BATTLERS_COUNT;
     SetVBlankCallback(VBlankCB_Battle);
-    // SetUpBattleVarsAndBirchZigzagoon();
+    SetUpBattleVarsAndBirchZigzagoon();
 
     if ((IsMultibattleTest() && gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER)
     || (gBattleTypeFlags & BATTLE_TYPE_MULTI && gBattleTypeFlags & BATTLE_TYPE_BATTLE_TOWER)

--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -70,8 +70,7 @@ static void CB2_EndWildBattle(void);
 static void CB2_EndScriptedWildBattle(void);
 static void TryUpdateGymLeaderRematchFromWild(void);
 static void TryUpdateGymLeaderRematchFromTrainer(void);
-// static void CB2_GiveStarter(void);
-static void CB2_GiveStarterNoBattle(void);
+static void CB2_GiveStarter(void);
 // static void CB2_StartFirstBattle(void);
 // static void CB2_EndFirstBattle(void);
 static void SaveChangesToPlayerParty(void);
@@ -874,23 +873,10 @@ enum BattleTransition GetSpecialBattleTransition(enum BattleTransitionGroup id)
 void ChooseStarter(void)
 {
     SetMainCallback2(CB2_ChooseStarter);
-    gMain.savedCallback = CB2_GiveStarterNoBattle;
+    gMain.savedCallback = CB2_GiveStarter;
 }
 
-// static void CB2_GiveStarter(void)
-// {
-//     u16 starterMon;
-//
-//     *GetVarPointer(VAR_STARTER_MON) = gSpecialVar_Result;
-//     starterMon = GetStarterPokemon(gSpecialVar_Result);
-//     ScriptGiveMon(starterMon, 5, ITEM_NONE);
-//     ResetTasks();
-//     PlayBattleBGM();
-//     SetMainCallback2(CB2_StartFirstBattle);
-//     BattleTransition_Start(B_TRANSITION_BLUR);
-// }
-
-static void CB2_GiveStarterNoBattle(void)
+static void CB2_GiveStarter(void)
 {
     UpdatePaletteFade();
     u16 starterMon;


### PR DESCRIPTION
This PR fixes battle engine issues introduced in #41. Specifically, the commented out code removing the initial zigzagoon battle included important battle initiation calls (setting the battler position, initializing controller functions, setting up AI, etc.). 