### PR TITLE
Fix Dawn Sprite Bug

### DIFF
--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -1514,6 +1514,16 @@ u8 GetPlayerAvatarGenderByGraphicsId(u16 gfxId)
     case OBJ_EVENT_GFX_MAY_UNDERWATER:
     case OBJ_EVENT_GFX_MAY_FISHING:
     case OBJ_EVENT_GFX_MAY_WATERING:
+    case OBJ_EVENT_GFX_DAWN_NORMAL:
+    case OBJ_EVENT_GFX_DAWN_BIKE:
+    case OBJ_EVENT_GFX_DAWN_FIELD_MOVE:
+    case OBJ_EVENT_GFX_DAWN_FISHING:
+    case OBJ_EVENT_GFX_DAWN_HEAL:
+    case OBJ_EVENT_GFX_DAWN_POKETCH:
+    case OBJ_EVENT_GFX_DAWN_SAVE:
+    case OBJ_EVENT_GFX_DAWN_SURF:
+    case OBJ_EVENT_GFX_DAWN_SEEKER:
+    case OBJ_EVENT_GFX_DAWN_WATERING:
         return FEMALE;
     default:
         return MALE;


### PR DESCRIPTION
This PR fixes a Dawn sprite bug that causes the player to be reverted to Lucas whenever the map is refreshed (e.g. viewing the trainer card). 