### PR TITLE
chore: add dockerized build environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+Dockerfile
+docker-compose.yml
+build/**

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ tools/agbcc
 *.sa*
 Thumbs.db
 build/
+dist/
 .DS_Store
 *.ddump
 .idea/

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,37 @@
+# Docker
+
+Build pokeemerald-platinum without installing the toolchain on your host machine.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) with Compose v2
+
+## Usage
+
+```bash
+# Build the ROM
+make docker-build
+
+# Open a shell inside the build environment
+make docker-shell
+
+# Remove the build + ccache volumes (full reset)
+make docker-clean
+```
+
+The finished ROM is written to `dist/pokeemerald.gba`.
+
+## How it works
+
+The container is an Ubuntu 24.04 image with the ARM cross-compilation toolchain (`gcc-arm-none-eabi`, `binutils-arm-none-eabi`) and build dependencies pre-installed. On first run Docker builds the image; subsequent runs reuse it.
+
+The build is **isolated from your host working tree** so it never touches your native build:
+
+- Your repo is mounted **read-only** at `/src`. The container cannot modify your sources, tool binaries, or build artifacts.
+- On each build, the sources are `rsync`-ed into a persistent `platinum_build` Docker volume at `/build`, and the compile happens there. The host-OS-specific outputs (`tools/*` binaries, `build/`) stay inside that volume - they are never written to your host `tools/` or `build/` directories.
+- Only the finished `pokeemerald.gba` is copied back out, to `dist/` on the host (the one writable host path), and `chown`-ed to your user.
+- A persistent `platinum_ccache` volume caches `ccache` data across builds, and the `platinum_build` volume keeps `build/` warm, so recompiles stay incremental.
+
+Because the build never writes to your host `tools/` or `build/`, you can freely alternate between `make` on the host and `make docker-build` without the two clobbering each other.
+
+If you want a completely fresh build (e.g. to reclaim disk or after a toolchain change), run `make docker-clean` to drop the `platinum_build` and `platinum_ccache` volumes; the next `make docker-build` repopulates them.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/usr/lib/ccache:${PATH}"
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    binutils-arm-none-eabi \
+    gcc-arm-none-eabi \
+    git \
+    make \
+    python3 \
+    ccache \
+    pkg-config \
+    rsync \
+    libpng-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CCACHE_DIR=/ccache
+
+WORKDIR /workspace
+
+CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -575,3 +575,15 @@ leafgreen: all
 # Symbol file (`make syms`)
 $(SYM): $(ELF)
 	$(OBJDUMP) -t $< | sort -u | grep -E "^0[2389]" | $(PERL) -p -e 's/^(\w{8}) (\w).{6} \S+\t(\w{8}) (\S+)$$/\1 \2 \3 \4/g' > $@
+
+.PHONY: docker-build docker-shell docker-clean
+
+docker-build:
+	mkdir -p dist
+	docker compose run --rm platinum
+
+docker-shell:
+	docker compose run --rm --entrypoint bash platinum -lc "rsync -a --delete --exclude='/build/' --exclude='/dist/' /src/ /build/ && cd /build && exec bash -l"
+
+docker-clean:
+	docker compose down -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  platinum:
+    build: .
+    environment:
+      CCACHE_DIR: /ccache
+    volumes:
+      # Host repo, mounted READ-ONLY. The container can never modify your sources,
+      # tool binaries, or build artifacts on the host.
+      - ./:/src:ro
+      # Isolated working copy where the build actually happens (tool binaries and
+      # build/ live here, inside the volume - never on the host). Persisted across
+      # runs so rebuilds stay incremental.
+      - platinum_build:/build
+      # Persistent ccache to speed up recompilation.
+      - platinum_ccache:/ccache
+      # The only writable host path: where the finished ROM is copied back out.
+      - ./dist:/dist
+    command: >
+      bash -lc "
+      rsync -a --delete --exclude='/build/' --exclude='/dist/' /src/ /build/ &&
+      cd /build &&
+      make clean-tools &&
+      make -j$$(nproc) &&
+      cp -f pokeemerald.gba /dist/pokeemerald.gba &&
+      { chown $$(stat -c '%u:%g' /src) /dist/pokeemerald.gba || true; }
+      "
+
+volumes:
+  platinum_build:
+  platinum_ccache:


### PR DESCRIPTION
## Summary

Adds a self-contained Docker build so the GBA ROM can be built without installing the ARM cross-compilation toolchain locally.

The build is **isolated from the host working tree**:
- The repo is mounted **read-only** at `/src` - the container cannot modify your sources, `tools/`, or `build/`.
- Sources are `rsync`-ed into a persistent `platinum_build` volume and compiled there, so host-OS-specific outputs (tool binaries, `build/`) never land on the host.
- Only the finished `pokeemerald.gba` is copied back, to `dist/`.
- Persistent `ccache` + `build` volumes keep recompiles incremental.

This lets native and Docker builds coexist without clobbering each other's `tools/`/`build/` outputs.

Files:
- `Dockerfile` - Ubuntu 24.04 + ARM toolchain, `libpng-dev`, `pkg-config`, `rsync`, `ccache`
- `docker-compose.yml` - `platinum` service, read-only source mount, isolated build/ccache volumes, ROM output to `dist/`
- `Makefile` - `docker-build` / `docker-shell` / `docker-clean` targets
- `DOCKER.md` - usage and isolation notes
- `.dockerignore`, `.gitignore` (`dist/`)

## Test plan

- [x] `make docker-build` produces a valid 32 MB ROM at `dist/pokeemerald.gba` ("POKEMON EMER", BPEE01)
- [x] Host `tools/` and `build/` are not written by the container (verified `/src` is `read_only`; build artifacts live in the `platinum_build` volume)
- [x] ROM output is owned by the host user