### PR TITLE
ci: build the ROM on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+# Cancel superseded runs on the same branch/PR to save CI minutes.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build ROM
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install toolchain and build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            binutils-arm-none-eabi \
+            gcc-arm-none-eabi \
+            git \
+            make \
+            python3 \
+            pkg-config \
+            libpng-dev
+
+      - name: Build ROM
+        run: make -j"$(nproc)"
+
+      - name: Upload ROM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pokeemerald.gba
+          path: pokeemerald.gba
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`.github/workflows/build.yml`) that **validates every PR compiles** by building the ROM.

- Runs on `pull_request` (any PR) and `push` to `master`.
- Uses `ubuntu-24.04` with `gcc-arm-none-eabi` / `binutils-arm-none-eabi` + build deps. Builds with `make -j"$(nproc)"` (the Makefile hardcodes `-DMODERN=1`; agbcc is deprecated, so no agbcc/devkitARM setup is needed).
- Uploads the resulting `pokeemerald.gba` as an artifact and **fails if the ROM isn't produced** (`if-no-files-found: error`).
- `concurrency` cancels superseded runs on the same ref.

## Test plan

- Verified green on a real run on the fork before retargeting here: the workflow installed the toolchain, ran `make`, and produced a valid `pokeemerald.gba`. Final confirmation is the CI run on this PR.