### PR TITLE
Add Rival Following Event reacting to Player Direction

### DIFF
--- a/data/maps/Route201/map.json
+++ b/data/maps/Route201/map.json
@@ -220,7 +220,7 @@
       "elevation": 0,
       "var": "VAR_ROUTE201_STATE",
       "var_value": "3",
-      "script": "Route201_EventScript_FollowLeave"
+      "script": "Route201_EventScript_FollowGrass"
     },
     {
       "type": "trigger",
@@ -229,7 +229,7 @@
       "elevation": 0,
       "var": "VAR_ROUTE201_STATE",
       "var_value": "3",
-      "script": "Route201_EventScript_FollowLeave"
+      "script": "Route201_EventScript_FollowGrass"
     },
     {
       "type": "trigger",
@@ -247,7 +247,7 @@
       "elevation": 0,
       "var": "VAR_ROUTE201_STATE",
       "var_value": "3",
-      "script": "Route201_EventScript_FollowLeave"
+      "script": "Route201_EventScript_FollowGrass"
     },
     {
       "type": "trigger",
@@ -274,7 +274,7 @@
       "elevation": 0,
       "var": "VAR_ROUTE201_STATE",
       "var_value": "1",
-      "script": "Route201_EventScript_FollowLeave"
+      "script": "Route201_EventScript_PickLeaveRight"
     },
     {
       "type": "trigger",

--- a/data/maps/Route201/map.json
+++ b/data/maps/Route201/map.json
@@ -220,7 +220,7 @@
       "elevation": 0,
       "var": "VAR_ROUTE201_STATE",
       "var_value": "3",
-      "script": "Route201_EventScript_FollowGrass"
+      "script": "Route201_EventScript_FollowLeave"
     },
     {
       "type": "trigger",
@@ -229,7 +229,7 @@
       "elevation": 0,
       "var": "VAR_ROUTE201_STATE",
       "var_value": "3",
-      "script": "Route201_EventScript_FollowGrass"
+      "script": "Route201_EventScript_FollowLeave"
     },
     {
       "type": "trigger",
@@ -247,7 +247,7 @@
       "elevation": 0,
       "var": "VAR_ROUTE201_STATE",
       "var_value": "3",
-      "script": "Route201_EventScript_FollowGrass2"
+      "script": "Route201_EventScript_FollowLeave"
     },
     {
       "type": "trigger",
@@ -274,7 +274,7 @@
       "elevation": 0,
       "var": "VAR_ROUTE201_STATE",
       "var_value": "1",
-      "script": "Route201_EventScript_PickLeaveRight"
+      "script": "Route201_EventScript_FollowLeave"
     },
     {
       "type": "trigger",

--- a/data/maps/Route201/scripts.inc
+++ b/data/maps/Route201/scripts.inc
@@ -664,6 +664,25 @@ Route201_EventScript_RivalTalk6::
 
 Route201_EventScript_FollowLeave::
 	lock
+
+	getobjectfacingdirection OBJ_EVENT_ID_PLAYER, VAR_0x8003
+
+	compare VAR_0x8003, DIR_NORTH
+	call_if_eq Route201_EventScript_FollowLeave_GoDown
+
+	compare VAR_0x8003, DIR_SOUTH
+	call_if_eq Route201_EventScript_FollowLeave_GoUp
+
+	compare VAR_0x8003, DIR_WEST
+	call_if_eq Route201_EventScript_FollowLeave_GoRight
+
+	compare VAR_0x8003, DIR_EAST
+	call_if_eq Route201_EventScript_FollowLeave_GoLeft
+
+	release
+	end
+
+Route201_EventScript_FollowLeave_GoUp:
 	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkInPlaceDown
 	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceUp
 	waitmovement 0
@@ -674,8 +693,46 @@ Route201_EventScript_FollowLeave::
 	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_FaceDown
 	waitmovement 0
 	delay 30
-	release
-	end
+	return
+
+Route201_EventScript_FollowLeave_GoDown:
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkInPlaceUp
+	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceDown
+	waitmovement 0
+	msgbox Route201_Text_FollowLeave, MSGBOX_SIGN
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkDown
+	applymovement LOCALID_PLAYER, Common_Movement_WalkDown
+	waitmovement 0
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_FaceUp
+	waitmovement 0
+	delay 30
+	return
+
+Route201_EventScript_FollowLeave_GoRight:
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkInPlaceLeft
+	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceRight
+	waitmovement 0
+	msgbox Route201_Text_FollowLeave, MSGBOX_SIGN
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkRight
+	applymovement LOCALID_PLAYER, Common_Movement_WalkRight
+	waitmovement 0
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_FaceLeft
+	waitmovement 0
+	delay 30
+	return
+
+Route201_EventScript_FollowLeave_GoLeft:
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkInPlaceRight
+	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceLeft
+	waitmovement 0
+	msgbox Route201_Text_FollowLeave, MSGBOX_SIGN
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkLeft
+	applymovement LOCALID_PLAYER, Common_Movement_WalkLeft
+	waitmovement 0
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_FaceRight
+	waitmovement 0
+	delay 30
+	return
 
 Route201_EventScript_FollowGrass::
 	lock

--- a/data/maps/Route201/scripts.inc
+++ b/data/maps/Route201/scripts.inc
@@ -726,6 +726,25 @@ Route201_EventScript_FollowLeave_GoLeft:
 
 Route201_EventScript_FollowGrass::
 	lock
+
+	getobjectfacingdirection OBJ_EVENT_ID_PLAYER, VAR_0x8003
+
+	compare VAR_0x8003, DIR_NORTH
+	call_if_eq Route201_EventScript_FollowGrass_GoDown
+
+	compare VAR_0x8003, DIR_SOUTH
+	call_if_eq Route201_EventScript_FollowGrass_GoUp
+
+	compare VAR_0x8003, DIR_WEST
+	call_if_eq Route201_EventScript_FollowGrass_GoRight
+
+	compare VAR_0x8003, DIR_EAST
+	call_if_eq Route201_EventScript_FollowGrass_GoLeft
+
+	release
+	end
+
+Route201_EventScript_FollowGrass_GoLeft:
 	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkInPlaceRight
 	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceLeft
 	waitmovement 0
@@ -736,6 +755,54 @@ Route201_EventScript_FollowGrass::
 	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkInPlaceRight
 	waitmovement 0
 	delay 30
+	return
+
+Route201_EventScript_FollowGrass_GoRight:
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkInPlaceLeft
+	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceRight
+	waitmovement 0
+	msgbox Route201_Text_FollowGrass, MSGBOX_SIGN
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkRight
+	applymovement LOCALID_PLAYER, Common_Movement_WalkRight
+	waitmovement 0
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkInPlaceLeft
+	waitmovement 0
+	delay 30
+	return
+
+Route201_EventScript_FollowGrass_GoUp:
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkInPlaceDown
+	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceUp
+	waitmovement 0
+	msgbox Route201_Text_FollowGrass, MSGBOX_SIGN
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkUp
+	applymovement LOCALID_PLAYER, Common_Movement_WalkUp
+	waitmovement 0
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkInPlaceDown
+	waitmovement 0
+	delay 30
+	return
+
+Route201_EventScript_FollowGrass_GoDown:
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkInPlaceUp
+	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceDown
+	waitmovement 0
+	msgbox Route201_Text_FollowGrass, MSGBOX_SIGN
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkDown
+	applymovement LOCALID_PLAYER, Common_Movement_WalkDown
+	waitmovement 0
+	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkInPlaceUp
+	waitmovement 0
+	delay 30
+	return
+
+Route201_EventScript_PickLeaveRight::
+	lock
+	applymovement LOCALID_ROUTE201_RIVAL, Common_Movement_WalkInPlaceDown
+	waitmovement 0
+	msgbox Route201_Text_WhatsUp, MSGBOX_SIGN
+	applymovement LOCALID_PLAYER, Common_Movement_WalkLeft
+	waitmovement 0
 	release
 	end
 

--- a/data/maps/Route201/scripts.inc
+++ b/data/maps/Route201/scripts.inc
@@ -423,16 +423,6 @@ Route201_Movement_HelperEnter:
 	walk_right
 	step_end
 
-Route201_EventScript_PickLeaveRight::
-	lock
-	applymovement LOCALID_ROUTE201_RIVAL, Common_Movement_WalkInPlaceDown
-	waitmovement 0
-	msgbox Route201_Text_WhatsUp, MSGBOX_SIGN
-	applymovement LOCALID_PLAYER, Common_Movement_WalkLeft
-	waitmovement 0
-	release
-	end
-
 Route201_EventScript_PickLeaveDown::
 	lock
 	applymovement LOCALID_ROUTE201_RIVAL, Common_Movement_WalkInPlaceDown
@@ -748,29 +738,6 @@ Route201_EventScript_FollowGrass::
 	delay 30
 	release
 	end
-
-Route201_EventScript_FollowGrass2::
-	lock
-	call_if_eq VAR_FACING, DIR_EAST, Route201_EventScript_FollowGrassWestApproach
-	call_if_eq VAR_FACING, DIR_NORTH, Route201_EventScript_FollowGrassSouthApproach
-	release
-	end
-
-Route201_EventScript_FollowGrassWestApproach::
-	goto Route201_EventScript_FollowGrass
-
-Route201_EventScript_FollowGrassSouthApproach::
-	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkInPlaceUp
-	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceDown
-	waitmovement 0
-	msgbox Route201_Text_FollowGrass, MSGBOX_SIGN
-	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_WalkDown
-	applymovement LOCALID_PLAYER, Common_Movement_WalkDown
-	waitmovement 0
-	applymovement OBJ_EVENT_ID_NPC_FOLLOWER, Common_Movement_FaceUp
-	waitmovement 0
-	delay 30
-	return
 
 Route201_EventScript_TipSign::
 	msgbox Route201_Text_TipSign, MSGBOX_SIGN


### PR DESCRIPTION
This PR resolves #79 by fixing a bug regarding the player direction being respected when attempting to leave the rival following event on Route 201. 