### PR TITLE
fix: enable NPC objects to use sideways stairs (#90)

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -6710,25 +6710,6 @@ bool8 ObjectEventIsHeldMovementActive(struct ObjectEvent *objectEvent)
     return FALSE;
 }
 
-// Map a walk/run movement action back to its cardinal direction. Each walk-speed
-// family is laid out DOWN, UP, LEFT, RIGHT == DIR_SOUTH, DIR_NORTH, DIR_WEST, DIR_EAST,
-// so the direction is the offset from the family's DOWN action plus DIR_SOUTH.
-// Returns DIR_NONE for any non-walk action (face, jump, delay, ...).
-static u8 GetMoveDirectionFromMovementActionId(u8 movementActionId)
-{
-    if (movementActionId >= MOVEMENT_ACTION_WALK_SLOW_DOWN && movementActionId <= MOVEMENT_ACTION_WALK_SLOW_RIGHT)
-        return movementActionId - MOVEMENT_ACTION_WALK_SLOW_DOWN + DIR_SOUTH;
-    if (movementActionId >= MOVEMENT_ACTION_WALK_NORMAL_DOWN && movementActionId <= MOVEMENT_ACTION_WALK_NORMAL_RIGHT)
-        return movementActionId - MOVEMENT_ACTION_WALK_NORMAL_DOWN + DIR_SOUTH;
-    if (movementActionId >= MOVEMENT_ACTION_WALK_FAST_DOWN && movementActionId <= MOVEMENT_ACTION_WALK_FAST_RIGHT)
-        return movementActionId - MOVEMENT_ACTION_WALK_FAST_DOWN + DIR_SOUTH;
-    if (movementActionId >= MOVEMENT_ACTION_WALK_FASTER_DOWN && movementActionId <= MOVEMENT_ACTION_WALK_FASTER_RIGHT)
-        return movementActionId - MOVEMENT_ACTION_WALK_FASTER_DOWN + DIR_SOUTH;
-    if (movementActionId >= MOVEMENT_ACTION_PLAYER_RUN_DOWN && movementActionId <= MOVEMENT_ACTION_PLAYER_RUN_RIGHT)
-        return movementActionId - MOVEMENT_ACTION_PLAYER_RUN_DOWN + DIR_SOUTH;
-    return DIR_NONE;
-}
-
 static u8 TryUpdateMovementActionOnStairs(struct ObjectEvent *objectEvent, u8 movementActionId)
 {
     u8 direction, currentBehavior, nextBehavior;
@@ -6738,17 +6719,19 @@ static u8 TryUpdateMovementActionOnStairs(struct ObjectEvent *objectEvent, u8 mo
      || objectEvent->localId == LOCALID_CAMERA)
         return movementActionId;    // handled separately
 
-    // movementDirection is stale here (only refreshed once the action executes), so
-    // derive the intended direction from the action id. Non-walk actions bail out.
-    direction = GetMoveDirectionFromMovementActionId(movementActionId);
-    if (direction == DIR_NONE)
+    // Only normal-speed scripted walks get the sideways-stairs slow climb (mirrors the
+    // player). movementDirection is stale here (only refreshed once the action executes),
+    // so derive the cardinal direction from the action id: WALK_NORMAL_{DOWN,UP,LEFT,RIGHT}
+    // is laid out as DIR_{SOUTH,NORTH,WEST,EAST}.
+    if (movementActionId < MOVEMENT_ACTION_WALK_NORMAL_DOWN || movementActionId > MOVEMENT_ACTION_WALK_NORMAL_RIGHT)
         return movementActionId;
+    direction = movementActionId - MOVEMENT_ACTION_WALK_NORMAL_DOWN + DIR_SOUTH;
 
     // Scripted/autonomous NPCs never run the player collision path that populates
     // directionOverwrite, so compute the sideways-stairs diagonal here (mirrors
     // follower_npc.c). ObjectMovingOnRockStairs then treats "E/W with directionOverwrite
-    // set" as a stair and the switch below converts the walk to WALK_SLOW_STAIRS - the
-    // same diagonal, slow climb the player performs on sideways stairs.
+    // set" as a stair, and we swap the walk for the WALK_SLOW_STAIRS action - the same
+    // diagonal, slow climb the player performs on sideways stairs.
     x = objectEvent->currentCoords.x;
     y = objectEvent->currentCoords.y;
     currentBehavior = MapGridGetMetatileBehaviorAt(x, y);
@@ -6768,19 +6751,7 @@ static u8 TryUpdateMovementActionOnStairs(struct ObjectEvent *objectEvent, u8 mo
     if (!ObjectMovingOnRockStairs(objectEvent, direction))
         return movementActionId;
 
-    switch (movementActionId)
-    {
-        case MOVEMENT_ACTION_WALK_NORMAL_DOWN:
-            return MOVEMENT_ACTION_WALK_SLOW_STAIRS_DOWN;
-        case MOVEMENT_ACTION_WALK_NORMAL_UP:
-            return MOVEMENT_ACTION_WALK_SLOW_STAIRS_UP;
-        case MOVEMENT_ACTION_WALK_NORMAL_LEFT:
-            return MOVEMENT_ACTION_WALK_SLOW_STAIRS_LEFT;
-        case MOVEMENT_ACTION_WALK_NORMAL_RIGHT:
-            return MOVEMENT_ACTION_WALK_SLOW_STAIRS_RIGHT;
-        default:
-            return movementActionId;
-    }
+    return GetWalkSlowStairsMovementAction(direction);
 }
 
 static const u8 sActionIdToCopyableMovement[] = {

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -6729,30 +6729,31 @@ static u8 GetMoveDirectionFromMovementActionId(u8 movementActionId)
     return DIR_NONE;
 }
 
-// Give regular NPCs the same sideways-stairs diagonal motion the player and followers
-// get. Scripted (applymovement) walks reach ObjectEventSetHeldMovement without ever
-// running the collision check that sets directionOverwrite, so without this they walk
-// straight through sideways stairs. The player (GetCollisionAtCoords) and followers
-// (follower_npc.c) set directionOverwrite in their own code, so they're bypassed here.
-static void TrySetSidewaysStairsDirectionOverwrite(struct ObjectEvent *objectEvent, u8 movementActionId)
+static u8 TryUpdateMovementActionOnStairs(struct ObjectEvent *objectEvent, u8 movementActionId)
 {
     u8 direction, currentBehavior, nextBehavior;
     s16 x, y;
 
     if (objectEvent->isPlayer || objectEvent->localId == OBJ_EVENT_ID_FOLLOWER || objectEvent->localId == OBJ_EVENT_ID_NPC_FOLLOWER
      || objectEvent->localId == LOCALID_CAMERA)
-        return;    // handled separately
+        return movementActionId;    // handled separately
 
+    // movementDirection is stale here (only refreshed once the action executes), so
+    // derive the intended direction from the action id. Non-walk actions bail out.
     direction = GetMoveDirectionFromMovementActionId(movementActionId);
     if (direction == DIR_NONE)
-        return;
+        return movementActionId;
 
+    // Scripted/autonomous NPCs never run the player collision path that populates
+    // directionOverwrite, so compute the sideways-stairs diagonal here (mirrors
+    // follower_npc.c). ObjectMovingOnRockStairs then treats "E/W with directionOverwrite
+    // set" as a stair and the switch below converts the walk to WALK_SLOW_STAIRS - the
+    // same diagonal, slow climb the player performs on sideways stairs.
     x = objectEvent->currentCoords.x;
     y = objectEvent->currentCoords.y;
     currentBehavior = MapGridGetMetatileBehaviorAt(x, y);
     MoveCoords(direction, &x, &y);
     nextBehavior = MapGridGetMetatileBehaviorAt(x, y);
-
     objectEvent->directionOverwrite = DIR_NONE;
     switch (GetSidewaysStairsCollision(objectEvent, direction, currentBehavior, nextBehavior, COLLISION_NONE))
     {
@@ -6763,15 +6764,8 @@ static void TrySetSidewaysStairsDirectionOverwrite(struct ObjectEvent *objectEve
         objectEvent->directionOverwrite = GetRightSideStairsDirection(direction);
         break;
     }
-}
 
-static u8 TryUpdateMovementActionOnStairs(struct ObjectEvent *objectEvent, u8 movementActionId)
-{
-    if (objectEvent->isPlayer || objectEvent->localId == OBJ_EVENT_ID_FOLLOWER || objectEvent->localId == OBJ_EVENT_ID_NPC_FOLLOWER
-     || objectEvent->localId == LOCALID_CAMERA)
-        return movementActionId;    // handled separately
-
-    if (!ObjectMovingOnRockStairs(objectEvent, objectEvent->movementDirection))
+    if (!ObjectMovingOnRockStairs(objectEvent, direction))
         return movementActionId;
 
     switch (movementActionId)
@@ -6808,9 +6802,6 @@ bool8 ObjectEventSetHeldMovement(struct ObjectEvent *objectEvent, u8 movementAct
         return TRUE;
 
     movementActionId = TryUpdateMovementActionOnStairs(objectEvent, movementActionId);
-    // Set diagonal directionOverwrite for regular NPCs walking on sideways stairs.
-    // Runs after the rock-stairs check above, which reads directionOverwrite itself.
-    TrySetSidewaysStairsDirectionOverwrite(objectEvent, movementActionId);
 
     UnfreezeObjectEvent(objectEvent);
     objectEvent->movementActionId = movementActionId;

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -6710,6 +6710,61 @@ bool8 ObjectEventIsHeldMovementActive(struct ObjectEvent *objectEvent)
     return FALSE;
 }
 
+// Map a walk/run movement action back to its cardinal direction. Each walk-speed
+// family is laid out DOWN, UP, LEFT, RIGHT == DIR_SOUTH, DIR_NORTH, DIR_WEST, DIR_EAST,
+// so the direction is the offset from the family's DOWN action plus DIR_SOUTH.
+// Returns DIR_NONE for any non-walk action (face, jump, delay, ...).
+static u8 GetMoveDirectionFromMovementActionId(u8 movementActionId)
+{
+    if (movementActionId >= MOVEMENT_ACTION_WALK_SLOW_DOWN && movementActionId <= MOVEMENT_ACTION_WALK_SLOW_RIGHT)
+        return movementActionId - MOVEMENT_ACTION_WALK_SLOW_DOWN + DIR_SOUTH;
+    if (movementActionId >= MOVEMENT_ACTION_WALK_NORMAL_DOWN && movementActionId <= MOVEMENT_ACTION_WALK_NORMAL_RIGHT)
+        return movementActionId - MOVEMENT_ACTION_WALK_NORMAL_DOWN + DIR_SOUTH;
+    if (movementActionId >= MOVEMENT_ACTION_WALK_FAST_DOWN && movementActionId <= MOVEMENT_ACTION_WALK_FAST_RIGHT)
+        return movementActionId - MOVEMENT_ACTION_WALK_FAST_DOWN + DIR_SOUTH;
+    if (movementActionId >= MOVEMENT_ACTION_WALK_FASTER_DOWN && movementActionId <= MOVEMENT_ACTION_WALK_FASTER_RIGHT)
+        return movementActionId - MOVEMENT_ACTION_WALK_FASTER_DOWN + DIR_SOUTH;
+    if (movementActionId >= MOVEMENT_ACTION_PLAYER_RUN_DOWN && movementActionId <= MOVEMENT_ACTION_PLAYER_RUN_RIGHT)
+        return movementActionId - MOVEMENT_ACTION_PLAYER_RUN_DOWN + DIR_SOUTH;
+    return DIR_NONE;
+}
+
+// Give regular NPCs the same sideways-stairs diagonal motion the player and followers
+// get. Scripted (applymovement) walks reach ObjectEventSetHeldMovement without ever
+// running the collision check that sets directionOverwrite, so without this they walk
+// straight through sideways stairs. The player (GetCollisionAtCoords) and followers
+// (follower_npc.c) set directionOverwrite in their own code, so they're bypassed here.
+static void TrySetSidewaysStairsDirectionOverwrite(struct ObjectEvent *objectEvent, u8 movementActionId)
+{
+    u8 direction, currentBehavior, nextBehavior;
+    s16 x, y;
+
+    if (objectEvent->isPlayer || objectEvent->localId == OBJ_EVENT_ID_FOLLOWER || objectEvent->localId == OBJ_EVENT_ID_NPC_FOLLOWER
+     || objectEvent->localId == LOCALID_CAMERA)
+        return;    // handled separately
+
+    direction = GetMoveDirectionFromMovementActionId(movementActionId);
+    if (direction == DIR_NONE)
+        return;
+
+    x = objectEvent->currentCoords.x;
+    y = objectEvent->currentCoords.y;
+    currentBehavior = MapGridGetMetatileBehaviorAt(x, y);
+    MoveCoords(direction, &x, &y);
+    nextBehavior = MapGridGetMetatileBehaviorAt(x, y);
+
+    objectEvent->directionOverwrite = DIR_NONE;
+    switch (GetSidewaysStairsCollision(objectEvent, direction, currentBehavior, nextBehavior, COLLISION_NONE))
+    {
+    case COLLISION_SIDEWAYS_STAIRS_TO_LEFT:
+        objectEvent->directionOverwrite = GetLeftSideStairsDirection(direction);
+        break;
+    case COLLISION_SIDEWAYS_STAIRS_TO_RIGHT:
+        objectEvent->directionOverwrite = GetRightSideStairsDirection(direction);
+        break;
+    }
+}
+
 static u8 TryUpdateMovementActionOnStairs(struct ObjectEvent *objectEvent, u8 movementActionId)
 {
     if (objectEvent->isPlayer || objectEvent->localId == OBJ_EVENT_ID_FOLLOWER || objectEvent->localId == OBJ_EVENT_ID_NPC_FOLLOWER
@@ -6753,6 +6808,9 @@ bool8 ObjectEventSetHeldMovement(struct ObjectEvent *objectEvent, u8 movementAct
         return TRUE;
 
     movementActionId = TryUpdateMovementActionOnStairs(objectEvent, movementActionId);
+    // Set diagonal directionOverwrite for regular NPCs walking on sideways stairs.
+    // Runs after the rock-stairs check above, which reads directionOverwrite itself.
+    TrySetSidewaysStairsDirectionOverwrite(objectEvent, movementActionId);
 
     UnfreezeObjectEvent(objectEvent);
     objectEvent->movementActionId = movementActionId;


### PR DESCRIPTION
## Summary

Regular NPCs ignored sideways-stairs metatiles during scripted movement because the held-movement path never set `directionOverwrite`. Fixes #90 by computing it in the shared `TryUpdateMovementActionOnStairs` funnel (reconciled with @blloop's WIP on `fix/npc-sideways-stairs`), so NPCs climb sideways stairs with the same diagonal slow-climb the player gets.

## Test plan

- [x] Builds via `make docker-build`
- [x] porygon-verified the Oreburgh rival event runs on normal tiles, so it's unaffected
- [ ] mGBA: scripted NPC climbs the real sideways stairs
- [ ] Regression: scripted walk on flat ground stays straight