### PR TITLE
Fix Jubilife Building Overworld Species

### DIFF
--- a/data/maps/JubilifeCity_TowerA_1F/map.json
+++ b/data/maps/JubilifeCity_TowerA_1F/map.json
@@ -41,7 +41,7 @@
       "flag": "0"
     },
     {
-      "graphics_id": "OBJ_EVENT_GFX_PIKACHU_DOLL",
+      "graphics_id": "OBJ_EVENT_GFX_SPECIES(PACHIRISU)",
       "x": 8,
       "y": 6,
       "elevation": 0,

--- a/data/maps/JubilifeCity_TowerB_1F/map.json
+++ b/data/maps/JubilifeCity_TowerB_1F/map.json
@@ -41,7 +41,7 @@
       "flag": "0"
     },
     {
-      "graphics_id": "OBJ_EVENT_GFX_PIKACHU",
+      "graphics_id": "OBJ_EVENT_GFX_SPECIES(PIKACHU)",
       "x": 6,
       "y": 5,
       "elevation": 0,


### PR DESCRIPTION
This PR closes #99 by updating the two instances of `OBJ_EVENT_GFX_PIKACHU_DOLL` to use the appropriate `OBJ_EVENT_GFX_SPECIES` macro instead. 