### PR TITLE
fix: give Rock Smash HM06 from Oreburgh Gate hiker

### DIFF
--- a/data/maps/OreburghGate/scripts.inc
+++ b/data/maps/OreburghGate/scripts.inc
@@ -5,7 +5,7 @@ OreburghGate_EventScript_Hiker::
 	lock
 	faceplayer
 	goto_if_eq VAR_OREBURGH_CITY_STATE, 0, OreburghGate_EventScript_HikerGive
-	msgbox OrebrughGate_Text_HiddenMachine, MSGBOX_NPC
+	msgbox OreburghGate_Text_HiddenMachine, MSGBOX_NPC
 	end
 
 OreburghGate_EventScript_HikerGive::
@@ -14,7 +14,7 @@ OreburghGate_EventScript_HikerGive::
 	goto_if_eq VAR_RESULT, FALSE, Common_EventScript_ShowBagIsFull
 	setflag FLAG_RECEIVED_HM_ROCK_SMASH
 	setvar VAR_OREBURGH_CITY_STATE, 1
-	msgbox OrebrughGate_Text_HiddenMachine, MSGBOX_DEFAULT
+	msgbox OreburghGate_Text_HiddenMachine, MSGBOX_DEFAULT
 	release
 	end
 
@@ -65,7 +65,7 @@ OreburghGate_Text_SparkingNew:
 	.string "So, let me make a gift of this Hidden\n"
 	.string "Machine to you!$"
 
-OrebrughGate_Text_HiddenMachine:
+OreburghGate_Text_HiddenMachine:
 	.string "That Hidden Machine, or HM for short,\n"
 	.string "contains the hidden move Rock Smash.\p"
 	.string "A Pokémon learning Rock Smash can\n"

--- a/data/maps/OreburghGate/scripts.inc
+++ b/data/maps/OreburghGate/scripts.inc
@@ -10,8 +10,9 @@ OreburghGate_EventScript_Hiker::
 
 OreburghGate_EventScript_HikerGive::
 	msgbox OreburghGate_Text_SparkingNew, MSGBOX_DEFAULT
-	giveitem ITEM_POTION
+	giveitem ITEM_HM_ROCK_SMASH
 	goto_if_eq VAR_RESULT, FALSE, Common_EventScript_ShowBagIsFull
+	setflag FLAG_RECEIVED_HM_ROCK_SMASH
 	setvar VAR_OREBURGH_CITY_STATE, 1
 	msgbox OrebrughGate_Text_HiddenMachine, MSGBOX_DEFAULT
 	release

--- a/src/field_move.c
+++ b/src/field_move.c
@@ -20,7 +20,7 @@ static bool32 IsFieldMoveUnlocked_Flash(void)
 
 static bool32 IsFieldMoveUnlocked_RockSmash(void)
 {
-    return FlagGet(FLAG_BADGE03_GET);
+    return FlagGet(FLAG_BADGE01_GET);
 }
 
 static bool32 IsFieldMoveUnlocked_Strength(void)


### PR DESCRIPTION
## Summary
The Oreburgh Gate hiker gave a Potion placeholder. He now gives the Rock Smash HM (HM06) and the move actually works once received.

Rock Smash was already HM06; the field-use gate was the problem: it required the third badge (Emerald's Dynamo Badge) while the hiker's dialog and the game's progression say the Oreburgh (first) badge is required.

## Changes
- `data/maps/OreburghGate/scripts.inc`: give `ITEM_HM_ROCK_SMASH` instead of `ITEM_POTION`, set `FLAG_RECEIVED_HM_ROCK_SMASH`.
- `src/field_move.c`: gate Rock Smash field use on `FLAG_BADGE01_GET` (Oreburgh) instead of `FLAG_BADGE03_GET`.

## Testing
- [x] `make docker-build` succeeds, ROM builds clean
- [ ] In-game: hiker gives HM06, Rock Smash usable in field after the Oreburgh badge

Fixes #111