### PR TITLE
Fix rival movement in Oreburgh City

### DIFF
--- a/data/maps/OreburghCityNorth/scripts.inc
+++ b/data/maps/OreburghCityNorth/scripts.inc
@@ -259,10 +259,8 @@ OreburghCityNorth_Movement_RivalLeaving:
     walk_left
     walk_left
 	walk_left
-	walk_up
     walk_left
 	walk_left
-	walk_up
     walk_left
     step_end
 


### PR DESCRIPTION
Rival leaving Oreburgh event was created before NPCs reacted to stairs metatiles during scripted movement. Because of that, rival movement is broken right now. This PR fixes that