### PR TITLE
Make Default Pokemon Name Uppercase

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -1115,7 +1115,7 @@ void CreateBoxMon(struct BoxPokemon *boxMon, u16 species, u8 level, u8 fixedIV, 
     SetBoxMonData(boxMon, MON_DATA_CHECKSUM, &checksum);
     EncryptBoxMon(boxMon);
     SetBoxMonData(boxMon, MON_DATA_IS_SHINY, &isShiny);
-    StringCopy(speciesName, GetSpeciesName(species));
+    StringCopyUppercase(speciesName, GetSpeciesName(species));
     SetBoxMonData(boxMon, MON_DATA_NICKNAME, speciesName);
     SetBoxMonData(boxMon, MON_DATA_LANGUAGE, &gGameLanguage);
     SetBoxMonData(boxMon, MON_DATA_OT_NAME, gSaveBlock2Ptr->playerName);


### PR DESCRIPTION
This PR fixes the default Pokemon name to be uppercase by changing the string copy function used for a Pokemon's name. 